### PR TITLE
Adjust behavior for failing tests when using requirements

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -993,7 +993,7 @@ class SpackSolverSetup(object):
 
         self.cfg_required_rules(pkg)
 
-    def condition(self, required_spec, imposed_spec=None, name=None, msg=None, _id=None):
+    def condition(self, required_spec, imposed_spec=None, name=None, msg=None):
         """Generate facts for a dependency or virtual provider condition.
 
         Arguments:
@@ -1010,7 +1010,7 @@ class SpackSolverSetup(object):
         named_cond.name = named_cond.name or name
         assert named_cond.name, "must provide name for anonymous condtions!"
 
-        condition_id = _id or next(self._condition_id_counter)
+        condition_id = next(self._condition_id_counter)
         self.gen.fact(fn.condition(condition_id, msg))
 
         # requirements trigger the condition
@@ -1768,7 +1768,7 @@ class SpackSolverSetup(object):
             self.gen.fact(fn.installed_hash(spec.name, h))
 
             # this describes what constraints it imposes on the solve
-            self.condition(spec, imposed_spec=spec, name=spec.name, _id=h)
+            self.impose(h, spec, body=True)
             self.gen.newline()
 
             # Declare as possible parts of specs that are not in package.py

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -936,8 +936,7 @@ error(2, "No valid version for '{0}' compiler '{1}' satisfies '@{2}'", Package, 
 % the compiler associated with the node satisfy the same constraint
 node_compiler_version_satisfies(Package, Compiler, Constraint)
   :- node_compiler_version(Package, Compiler, Version),
-     compiler_version_satisfies(Compiler, Constraint, Version),
-     build(Package).
+     compiler_version_satisfies(Compiler, Constraint, Version).
 
 #defined compiler_version_satisfies/3.
 
@@ -1130,25 +1129,25 @@ opt_criterion(100, "number of packages to build (vs. reuse)").
 #minimize { 1@100,Package : build(Package), optimize_for_reuse() }.
 #defined optimize_for_reuse/0.
 
-% Minimize the number of deprecated versions being used
-opt_criterion(75, "deprecated versions used").
-#minimize{ 0@275: #true }.
-#minimize{ 0@75: #true }.
-#minimize{
-    1@75+Priority,Package
-    : deprecated(Package, _),
-      build_priority(Package, Priority)
-}.
-
 % A condition group specifies one or more specs that must be satisfied.
 % Specs declared first are preferred, so we assign increasing weights and
 % minimize the weights.
-opt_criterion(73, "requirement weight").
+opt_criterion(75, "requirement weight").
+#minimize{ 0@275: #true }.
+#minimize{ 0@75: #true }.
+#minimize {
+    Weight@75+Priority
+    : requirement_weight(Package, Weight),
+      build_priority(Package, Priority)
+}.
+
+% Minimize the number of deprecated versions being used
+opt_criterion(73, "deprecated versions used").
 #minimize{ 0@273: #true }.
 #minimize{ 0@73: #true }.
-#minimize {
-    Weight@73+Priority
-    : requirement_weight(Package, Weight),
+#minimize{
+    1@73+Priority,Package
+    : deprecated(Package, _),
       build_priority(Package, Priority)
 }.
 


### PR DESCRIPTION
Modifications:
- [x] Fix failing unit-tests by deriving an atom for concretized specs
- [x] Also switch requirements and deprecated versions priority

Feel free to merge this onto your branch, if that seems fine.